### PR TITLE
Patch 1

### DIFF
--- a/posts/2016-07-26-union-type-in-idris-part-1.html
+++ b/posts/2016-07-26-union-type-in-idris-part-1.html
@@ -54,7 +54,7 @@ myAlcohol <span class="fu">=</span> <span class="dt">AlcoholWhisky</span> (<span
 
 <span class="ot">myBeverage ::</span> <span class="dt">Beverage</span>
 myBeverage <span class="fu">=</span> <span class="dt">BeverageAlcohol</span> myAlcohol</code></pre></div>
-<p>It would be easier if we can claim that a type <code>t</code> is a union of several types and provides any of these types vaule as a value of type <code>t</code>.</p>
+<p>It would be easier if we can claim that a type <code>t</code> is a union of several types and provides any of these types value as a value of type <code>t</code>.</p>
 <p>This idea is not new, it’s for example investigated in the <a href="http://hackage.haskell.org/package/open-union"><code>open-union</code></a> package. Thanks to this package, we can replace the first example with something like:</p>
 <div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="kw">type</span> <span class="dt">Alcohol</span> <span class="fu">=</span> <span class="dt">Union</span> <span class="ch">'[Whisky, Beer]</span>
 
@@ -65,8 +65,8 @@ myAlcohol <span class="fu">=</span> liftUnion (<span class="dt">Whisky</span> <s
 <h1 id="defining-union-types-in-idris">Defining union types in Idris</h1>
 <p><a href="http://www.idris-lang.org/">Idris</a> is a purely functional programming language with dependent-type designed by Edwin Brady. I assume here a basic knowledge of Idris and of dependent types.</p>
 <h2 id="declaring-union-types">Declaring union types</h2>
-<p>Suppose that you can promote the values as types, how would it helps to build an union type? This question was the one that started the journey.</p>
-<p>Here was the idea: we can define a type as a list of type. From there, it suffices to find a way to “point” the valid type in our union and we obtain an union for free. Here is the implementation:</p>
+<p>Suppose that you can promote the values as types, how would it helps to build a union type? This question was the one that started the journey.</p>
+<p>Here was the idea: we can define a type as a list of type. From there, we simply need to find a way to “point” the valid type in our union and we obtain a union for free. Here is the implementation:</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="kw">data</span> <span class="dt">Union</span> <span class="ot">:</span> <span class="dt">List</span> <span class="dt">Type</span> <span class="ot">-&gt;</span> <span class="dt">Type</span> <span class="kw">where</span>
   <span class="dt">MemberHere</span> <span class="ot">:</span> ty <span class="ot">-&gt;</span> <span class="dt">Union</span> (ty<span class="ot">::</span>ts)
   <span class="dt">MemberThere</span> <span class="ot">:</span> <span class="dt">Union</span> ts <span class="ot">-&gt;</span> <span class="dt">Union</span> (ty<span class="ot">::</span>ts)</code></pre></div>
@@ -83,16 +83,16 @@ x <span class="fu">=</span> <span class="dt">MemberThere</span> (<span class="dt
 member x {e <span class="fu">=</span> <span class="dt">Here</span>} <span class="fu">=</span> <span class="dt">MemberHere</span> x
 member x {e <span class="fu">=</span> <span class="dt">There</span> later} <span class="fu">=</span>
   <span class="dt">MemberThere</span> (member x {e <span class="fu">=</span> later})</code></pre></div>
-<p>This short function takes advantages of Idris <a href="http://docs.idris-lang.org/en/latest/tutorial/miscellany.html#auto-implicit-arguments">auto implicit arguments</a>, which automatically computes argument at compile times, depending on the executino context. The idea is that, given a type <code>ty</code>, such that <code>ty</code> is in the union, we can compute the location of this type in the union and provide an <code>Elem</code>. This <code>Elem</code> is then used to compute the <code>Union</code> boilerplate. An we obtain:</p>
+<p>This short function takes advantages of Idris <a href="http://docs.idris-lang.org/en/latest/tutorial/miscellany.html#auto-implicit-arguments">auto implicit arguments</a>, which automatically computes argument at compile times, depending on the execution context. The idea is that given a type <code>ty</code>, such that <code>ty</code> is in the union, we can compute the location of this type in the union and provide an <code>Elem</code>. This <code>Elem</code> is then used to compute the <code>Union</code> boilerplate. An we obtain:</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="fu">x</span> <span class="ot">:</span> <span class="dt">Union</span> [<span class="dt">String</span>, <span class="dt">Nat</span>, <span class="dt">List</span> <span class="dt">String</span>]
 x <span class="fu">=</span> member <span class="st">&quot;Ahoy!&quot;</span>
 
 <span class="fu">y</span> <span class="ot">:</span> <span class="dt">Union</span> [<span class="dt">String</span>, <span class="dt">Nat</span>, <span class="dt">List</span> <span class="dt">String</span>]
 x <span class="fu">=</span> member <span class="dv">3</span></code></pre></div>
-<p>Note that as complex as the union will be, the instanciation will always straightforward.</p>
+<p>Note that as complex as the union will be, the instantiation will always be straightforward.</p>
 <h2 id="extracting-union-type">Extracting union type</h2>
-<p>Ok, so union type are easy to declare and to instanciate. We also need an easy way to get our value back if we want to compete with sun types.</p>
-<p>Let’s define a <code>get</code> function that extract a value of type <code>ty</code> from an union. To typecheck, <code>ty</code> must be a valid type (a type listed in the union). And we can’t be sure to obtain a <code>ty</code>. Thus, the type of <code>get</code> is:</p>
+<p>Ok, so union type are easy to declare and to instantiate. We also need an easy way to get our value back if we want to compete with sum types.</p>
+<p>Let’s define a <code>get</code> function that extract a value of type <code>ty</code> from a union. To typecheck, <code>ty</code> must be a valid type (a type listed in the union). And we can’t be sure to obtain a <code>ty</code>. Thus, the type of <code>get</code> is:</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="fu">get</span> <span class="ot">:</span> <span class="dt">Union</span> ts <span class="ot">-&gt;</span> {<span class="kw">auto</span> p<span class="ot">:</span> <span class="dt">Elem</span> ty ts} <span class="ot">-&gt;</span> <span class="dt">Maybe</span> ty</code></pre></div>
 <p>And once again, the idea is to use the witness of the type position in the union (<code>p</code>) to compute the answer.</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="fu">get</span> <span class="ot">:</span> <span class="dt">Union</span> ts <span class="ot">-&gt;</span> {<span class="kw">auto</span> e<span class="ot">:</span> <span class="dt">Elem</span> ty ts} <span class="ot">-&gt;</span> <span class="dt">Maybe</span> ty
@@ -107,7 +107,7 @@ get (<span class="dt">MemberThere</span> later) {e <span class="fu">=</span> <sp
 <span class="dt">Just</span> <span class="st">&quot;Ahoy!&quot;</span> <span class="ot">:</span> <span class="dt">Maybe</span> <span class="dt">String</span>
 <span class="fu">&gt;&gt;&gt;</span> the (<span class="dt">Maybe</span> <span class="dt">Nat</span>) <span class="fu">$</span> get x
 <span class="dt">Nothing</span> <span class="ot">:</span> <span class="dt">Maybe</span> <span class="dt">Nat</span></code></pre></div>
-<p>We uset <code>the</code> here to provide a Type hint, but it won’t be useful in most of the cases, as the type will be provided by the context.</p>
+<p>We use <code>the</code> here to provide a Type hint, but it won’t be useful in most cases, as the type will be provided by the context.</p>
 <h1 id="part-1-is-over">Part 1 is over</h1>
 <p>That’s all for today, you can continue with the fold for <a href="http://nicolas.biri.name/posts/2016-07-27-union-type-in-idris-part-2.html">union type</a>.</p>
 

--- a/posts/2016-07-27-union-type-in-idris-part-2.html
+++ b/posts/2016-07-27-union-type-in-idris-part-2.html
@@ -32,7 +32,7 @@
 
 <p>The <a href="http://nicolas.biri.name/posts/2016-07-26-union-type-in-idris-part-1.html">first part</a>.</p>
 <h1 id="first-part-summary">First part summary</h1>
-<p>We have detailed how we can write union types in Idris and how to extract a value from it. We recall here the union type definition, that is used through this article:</p>
+<p>We have detailed how we can write union types in Idris and how to extract a value from them. We recall here the union type definition that is used through this article:</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="kw">data</span> <span class="dt">Union</span> <span class="ot">:</span> <span class="dt">List</span> <span class="dt">Type</span> <span class="ot">-&gt;</span> <span class="dt">Type</span> <span class="kw">where</span>
   <span class="dt">MemberHere</span> <span class="ot">:</span> ty <span class="ot">-&gt;</span> <span class="dt">Union</span> (ty<span class="ot">::</span>ts)
   <span class="dt">MemberThere</span> <span class="ot">:</span> <span class="dt">Union</span> ts <span class="ot">-&gt;</span> <span class="dt">Union</span> (ty<span class="ot">::</span>ts)</code></pre></div>
@@ -41,7 +41,7 @@
 <span class="fu">get</span> <span class="ot">:</span> <span class="dt">Union</span> ts <span class="ot">-&gt;</span> {<span class="kw">auto</span> p<span class="ot">:</span> <span class="dt">Elem</span> ty ts} <span class="ot">-&gt;</span> <span class="dt">Maybe</span> ty</code></pre></div>
 <h1 id="folding-union">Folding Union</h1>
 <p>When I started reading some Idris, I was amazed by the <a href="https://gist.github.com/puffnfresh/11202637"><code>printf</code> example</a> (also available <a href="https://www.youtube.com/watch?v=fVBck2Zngjo">in video</a>).</p>
-<p>And my motivation when I start union type was actually to provide a type safe way to fold an union type.</p>
+<p>And my motivation when I started union type was actually to provide a type-safe way to fold an union type.</p>
 <h2 id="a-first-try-decomposing-the-union-type">A first try: Decomposing the union type</h2>
 <p>So my first idea was to decompose the union to know which functions we need to cover all the cases.. It means that I wanted something like:</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="fu">&gt;</span> <span class="ot">:</span>t foldUnion (the (<span class="dt">Union</span> [<span class="dt">Char</span>, <span class="dt">String</span>]) <span class="fu">$</span> member <span class="ch">'c'</span>)
@@ -50,7 +50,7 @@ foldUnion (the (<span class="dt">Union</span> [<span class="dt">Char</span>, <sp
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="fu">foldUnion</span> <span class="ot">:</span> (u<span class="ot">:</span> <span class="dt">Union</span> ts) <span class="ot">-&gt;</span> <span class="dt">UnionFold</span> ts</code></pre></div>
 <p>Where <code>UnionFold</code> should build a type from a list of type.</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="dt">UnionFold</span> <span class="ot">:</span> <span class="dt">List</span> <span class="dt">Type</span> <span class="ot">-&gt;</span> <span class="dt">Type</span></code></pre></div>
-<p>The case decoposition is quite straightforward atually. If the list is empty, we are done, so the type should be an arbitrary <code>a</code>. If there is a type in the list, we should provide a function for this type and continue with the tail of the list:</p>
+<p>The case decomposition is actually quite straightforward. If the list is empty, we are done, so the type should be an arbitrary <code>a</code>. If there is a type in the list, we should provide a function for this type and continue with the tail of the list:</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="dt">UnionFold</span> <span class="ot">:</span> <span class="dt">List</span> <span class="dt">Type</span> <span class="ot">-&gt;</span> <span class="dt">Type</span>
 <span class="dt">UnionFold</span> [] <span class="fu">=</span> a
 <span class="dt">UnionFold</span> (ty<span class="ot">:</span>ts) <span class="fu">=</span> (ty <span class="ot">-&gt;</span> a) <span class="ot">-&gt;</span> <span class="dt">UnionFold</span> ts</code></pre></div>
@@ -69,12 +69,12 @@ foldUnion (<span class="dt">MemberThere</span> later) <span class="fu">=</span> 
 <span class="fu">&gt;&gt;&gt;</span> foldUnion x length id (sum <span class="fu">.</span> map length)
 <span class="dv">5</span> <span class="ot">:</span> <span class="dt">Nat</span></code></pre></div>
 <h2 id="functions-to-the-left-union-to-the-right">Functions to the left, union to the right</h2>
-<p>There is an issue with the former proposal: we need to provide the unon first. It makes sense in the case of <code>printf</code>, as we want to provide the format string before its parameter. It’s less meaningful in the case of folding.</p>
-<p>It’s pretty hard to change the parameter order though. Actually, if we dont know the union, how can we know if we still have to pass a function or the final union. More clearly, we aren’t able to define the type of a partially applied function.</p>
+<p>There is an issue with the former proposal: we need to provide the union first. It makes sense in the case of <code>printf</code>, as we want to provide the format string before its parameter. It’s less meaningful in the case of folding.</p>
+<p>It’s pretty hard to change the parameters order though. Actually, if we dont know the union, how can we know if we still have to pass a function or the final union. To put it simply, we aren’t able to define the type of a partially applied function.</p>
 <p>An alternative is to gather the folding functions to define what kind of unions can be fold with these functions.</p>
 <p>The objective is consequently to obtain a signature like:</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="fu">foldUnion</span> <span class="ot">:</span> <span class="dt">UnionFold</span> a ts <span class="ot">-&gt;</span> (u<span class="ot">:</span> <span class="dt">Union</span> ts) <span class="ot">-&gt;</span> a</code></pre></div>
-<p>With this signature, <code>UnionFold a ts</code> indicates that we have sufficient functions to fold an <code>Union ts</code>, to provide an <code>a</code>. My goal was to be able to build this UnionFold as easily as possible. I take advantage of the <a href="http://docs.idris-lang.org/en/latest/tutorial/typesfuns.html#list-and-vect">list syntax in Idris</a> to obtain a convenient way to define it. So <code>UnionFold a ts</code> is defined as:</p>
+<p>With this signature, <code>UnionFold a ts</code> indicates that we have sufficient functions to fold an <code>Union ts</code>, to provide an <code>a</code>. My goal was to be able to build this UnionFold as easily as possible. I took advantage of the <a href="http://docs.idris-lang.org/en/latest/tutorial/typesfuns.html#list-and-vect">list syntax in Idris</a> to obtain a convenient way to define it. So <code>UnionFold a ts</code> is defined as:</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="kw">data</span> <span class="dt">UnionFold</span> <span class="ot">:</span> (target<span class="ot">:</span> <span class="dt">Type</span>) <span class="ot">-&gt;</span> (union<span class="ot">:</span> <span class="dt">Type</span>) <span class="ot">-&gt;</span> <span class="dt">Type</span> <span class="kw">where</span>
   <span class="dt">Nil</span> <span class="ot">:</span> <span class="dt">UnionFold</span> a (<span class="dt">Union</span> [])
   <span class="fu">(::)</span> <span class="ot">:</span> (t <span class="ot">-&gt;</span> a) <span class="ot">-&gt;</span> <span class="dt">UnionFold</span> a (<span class="dt">Union</span> ts)
@@ -87,7 +87,7 @@ foldUnion [] (<span class="dt">MemberHere</span> <span class="fu">_</span>) <spa
 foldUnion [] (<span class="dt">MemberThere</span> <span class="fu">_</span>) <span class="kw">impossible</span>
 foldUnion (f <span class="ot">::</span> <span class="fu">_</span>) (<span class="dt">MemberHere</span> y) <span class="fu">=</span> f y
 foldUnion (f <span class="ot">::</span> xs) (<span class="dt">MemberThere</span> y) <span class="fu">=</span> foldUnion xs y</code></pre></div>
-<p>The two first cases (ithe impossible ones) can be omited (as they are impossible). I added them for documentation purpose. The two last cases are quite easy to read: we go through the <code>UnionFold</code> and the <code>Union</code> simultaneously and as soon as we fan the right location, we apply the corresponding function.</p>
+<p>The two first cases (the impossible ones) can be omitted (as they are impossible). I added them for documentation purpose. The two last cases are quite easy to read: we go through the <code>UnionFold</code> and the <code>Union</code> simultaneously and as soon as we find the right location, we apply the corresponding function.</p>
 <p>And the previous example became:</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="fu">&gt;&gt;&gt;</span> <span class="ot">:</span><span class="kw">let</span> x <span class="fu">=</span> the (<span class="dt">Union</span> [<span class="dt">String</span>, <span class="dt">Nat</span>, <span class="dt">List</span> <span class="dt">String</span>]) <span class="fu">$</span> member <span class="st">&quot;Ahoy!&quot;</span>
 <span class="fu">&gt;&gt;&gt;</span> foldUnion [length, id, sum <span class="fu">.</span> map length] x

--- a/posts/2016-07-28-union-type-in-idris-part-3.html
+++ b/posts/2016-07-28-union-type-in-idris-part-3.html
@@ -32,15 +32,15 @@
 
 <p>Go back to the <a href="http://nicolas.biri.name/posts/2016-07-26-union-type-in-idris-part-1.html">first part</a>.</p>
 <h1 id="some-are-better-than-others-union-is-better-than-sum">Some are better than others, Union is better than sum</h1>
-<p>At this point, we have a slightly less complex syntax than sum types (with some drawbacks, but I will detail them in another part), but did we have other benefits?</p>
+<p>At this point, we managed to get a slightly less complex syntax than sum types (with some drawbacks, but I will detail them in another part), but did we obtain other benefits?</p>
 <p>Well, yes.</p>
-<p>Today, we are going to inverstigate how flexible union types are. More precisely, I will detail union type restrictions and generalisation.</p>
+<p>Today, we are going to invertigate how flexible union types are. More precisely, I will detail union type restrictions and generalisation.</p>
 <h1 id="shrink-my-union">Shrink my union</h1>
-<p>Let suppose that we have a variable <code>x</code> of type <code>Union [Nat, String, List String]</code> and the following repl session:</p>
+<p>Let suppose that we have a variable <code>x</code> of type <code>Union [Nat, String, List String]</code> and the following REPL session:</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="fu">&gt;</span> the (<span class="dt">Maybe</span> <span class="dt">Nat</span>) x
 <span class="dt">Nothing</span> <span class="ot">:</span> <span class="dt">Maybe</span> <span class="dt">Nat</span></code></pre></div>
 <p>We know that <code>x</code> does not contain a <code>Nat</code>. Thus, <code>x</code> contains either a <code>String</code> or a <code>List String</code>. Well, we can explicitly express it with union types.</p>
-<p>Let’s compute the type of this reasoning. Given an union instance, we can either get a value of a type in this uion or we can restrict the union. Quite clear and easy to write:</p>
+<p>Let’s compute the underlying type of this reasoning. Given a union instance, we can either get a value of a type in this union or we can restrict the union. Quite clear and easy to write:</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="fu">retract</span> <span class="ot">:</span> <span class="dt">Union</span> xs <span class="ot">-&gt;</span> {<span class="kw">auto</span> p<span class="ot">:</span> <span class="dt">Elem</span> ty xs}
                    <span class="ot">-&gt;</span> <span class="dt">Either</span> (<span class="dt">Union</span> (dropElem xs p)) ty</code></pre></div>
 <p>The result type may require some explanations. The presence of <code>Either</code> and the right case (<code>ty</code>) is clear. The left case (<code>dropElem xs p</code>) is straightforward if we look at the <a href="http://www.idris-lang.org/docs/current/base_doc/docs/Data.List.html#Data.List.dropElem"><code>dropElem</code> documentation</a>: it removes the element pointed by <code>p</code> from the list.</p>
@@ -56,7 +56,7 @@ retract (<span class="dt">MemberThere</span> x) {p <span class="fu">=</span> (<s
   either (<span class="dt">Left</span> <span class="fu">.</span> <span class="dt">MemberThere</span>)
          <span class="dt">Right</span>
          <span class="fu">$</span> retract x {p <span class="fu">=</span> later}</code></pre></div>
-<p>The 3 first cases are trivial, they can almost be completed automatically by Idris (I should talk about this really cool feature in a next post). The last case is a bit more complex. The idea is to <em>lift</em> the result of retract to the next step: on a right, propagate the found value, on a left, just buried it one step further.</p>
+<p>The 3 first cases are trivial, they can almost be completed automatically by Idris (I should talk about this really cool feature in a next post). The last case is a bit more complex. The idea is to <em>lift</em> the result of retract to the next step: on a right, propagate the found value, on a left, just bury it one step further.</p>
 <p>It’s time to see retract in action:</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="fu">&gt;</span> <span class="ot">:</span><span class="kw">let</span> x <span class="fu">=</span> the (<span class="dt">Union</span> [<span class="dt">Nat</span>, <span class="dt">String</span>, <span class="dt">List</span> <span class="dt">String</span>]) <span class="fu">$</span> member <span class="st">&quot;foo&quot;</span>
 <span class="fu">&gt;</span> the (<span class="dt">Either</span> <span class="fu">_</span> <span class="dt">Nat</span>) <span class="fu">$</span> retract x
@@ -67,24 +67,24 @@ retract (<span class="dt">MemberThere</span> x) {p <span class="fu">=</span> (<s
 <p>Can we do the opposite of <code>retract</code>? If I have a member of <code>Union [Nat, List String]</code>, can we claim that we have a member of a broader union?</p>
 <p>Yes, we can <em>but</em> it is a bit more complex than the <code>retract</code> case. The main reason is that we have an infinity of target types for the result union.</p>
 <h2 id="identifying-the-broader-unions">Identifying the broader unions</h2>
-<p>The objective is to define a data type that contain a proof that an union is broader than another one. Or, by transitivity, that each element of a list of types is contained in another list. This is as simple as it sounds. I mean, really, if its sounds complicated to you, it will be complicated to read, if it sounds simple, it will be simple to read:</p>
+<p>The objective is to define a data type that contains a proof that a union is broader than another one. Or, by transitivity, that each element of a list of types is contained in another list. This is as simple as it sounds. I mean, really, if its sounds complicated to you, it will be complicated to read, if it sounds simple, it will be simple to read:</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="kw">data</span> <span class="dt">Sub</span> <span class="ot">:</span> <span class="dt">List</span> a <span class="ot">-&gt;</span> <span class="dt">List</span> a <span class="ot">-&gt;</span> <span class="dt">Type</span> <span class="kw">where</span>
   <span class="dt">SubZ</span> <span class="ot">:</span> <span class="dt">Sub</span> [] ys
   <span class="dt">SubK</span> <span class="ot">:</span> <span class="dt">Sub</span> xs ys <span class="ot">-&gt;</span>  <span class="dt">Elem</span> ty ys <span class="ot">-&gt;</span> <span class="dt">Sub</span> (ty<span class="ot">::</span>xs) ys</code></pre></div>
-<p>To build a <code>Sub</code> type, we must be able proof that each element of the first list are in the second one.</p>
+<p>To build a <code>Sub</code> type, we must be able to prove that each element of the first list is in the second one.</p>
 <h2 id="trying-to-generalize-union">Trying to <code>generalize</code> union</h2>
 <p>Now that we have a definition of <code>Sub</code>, we can type our <code>generalize</code> function more easily:</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="fu">generalize</span> <span class="ot">:</span> (u<span class="ot">:</span> <span class="dt">Union</span> xs) <span class="ot">-&gt;</span> {<span class="kw">auto</span> s<span class="ot">:</span> <span class="dt">Sub</span> xs ys}
                            <span class="ot">-&gt;</span> <span class="dt">Union</span> ys</code></pre></div>
-<p>Given an union, if we have a proof that the list of type in the union is a subset of the list of type in the resulting union, we can generalize the union. Yes, it’s that <strong>easy</strong>.</p>
+<p>Given a union, if we have a proof that the list of type in the union is a subset of the list of type in the resulting union, we can generalize the union. Yes, it’s that <strong>easy</strong>.</p>
 <p>Things are getting more complex when we want to implement generalize. Let’s start with a naive implementation and see how it goes:</p>
 <div class="sourceCode"><pre class="sourceCode idris"><code class="sourceCode idris"><span class="fu">generalize</span> <span class="ot">:</span> (u<span class="ot">:</span> <span class="dt">Union</span> xs) <span class="ot">-&gt;</span> {<span class="kw">auto</span> s<span class="ot">:</span> <span class="dt">Sub</span> xs ys}
                            <span class="ot">-&gt;</span> <span class="dt">Union</span> ys
 generalize (<span class="dt">MemberHere</span> x) <span class="fu">=</span> member x
 generalize (<span class="dt">MemberThere</span> x) {s <span class="fu">=</span> (<span class="dt">SubK</span> y z)} <span class="fu">=</span>
   generalize x {s<span class="fu">=</span>y}</code></pre></div>
-<p>If we have at <code>MemberHere</code>, <code>x</code> is the value of the union, and thus, must be put in the result union, and we use previously defined <code>member</code> to do so. If we haven’t find the value yet, we just restart one step further.</p>
-<p>This version reallly seemed ok to me. Unfortunately, it didn’t match the compiler expactations:</p>
+<p>If we have at <code>MemberHere</code>, <code>x</code> is the value of the union, and thus, must be put in the result union, and we use previously defined <code>member</code> to do so. If we haven’t found the value yet, we just restart one step further.</p>
+<p>This version reallly seemed ok to me. Unfortunately, it didn’t match the compiler expectations:</p>
 <pre><code>When checking right hand side of generalize with expected type
         Union ys
 


### PR DESCRIPTION
Fix a few typo, grammar mistakes and gallicism in the posts related to Union Type.

Note specifically that you cannot write "an union", because the rule of adding an "n" in front of a is never applied for words starting with the "iou" sound. So you write "a university", "a union", "a unique occasion" (but "an umpire", "an unused function", etc.).